### PR TITLE
Fix and unittest for issue #58 

### DIFF
--- a/library/fortimgr_policy.py
+++ b/library/fortimgr_policy.py
@@ -2362,13 +2362,14 @@ def main():
         locked = dict(locked=True, saved=True, unlocked=True)
         results.update(locked)
 
-    # get policy id to be used to move the policy to the correct order per module params
-    if "policyid" in proposed:
-        policy_id = proposed["policyid"]
-    else:
-        policy_id = results["config"]["id"]
 
     if state != "absent":
+        # get policy id to be used to move the policy to the correct order per module params
+        if "policyid" in proposed:
+            policy_id = proposed["policyid"]
+        else:
+            policy_id = results["config"]["id"]
+
         moved = session.config_move(module, policy_id, results)
 
         # if module has made it this far and lock set, then all related return values are true

--- a/unittests/fortimgr_policy_unittest.yml
+++ b/unittests/fortimgr_policy_unittest.yml
@@ -127,6 +127,16 @@
   tags: policy
 
   tasks:
+    - name: DELETE INEXISTANT POLICY - NO CHANGE
+      fortimgr_policy:
+        host: "{{ inventory_hostname }}"
+        session_id: "{{ session_id }}"
+        lock: false
+        adom: "lab"
+        package: "lab"
+        policy_name: "unittest_inexistant_policy_name"
+        state: "absent"
+
     - name: CREATE DENY POLICY - CHANGE
       fortimgr_policy:
         host: "{{ inventory_hostname }}"

--- a/unittests/fortimgr_policy_unittest.yml
+++ b/unittests/fortimgr_policy_unittest.yml
@@ -127,14 +127,14 @@
   tags: policy
 
   tasks:
-    - name: DELETE NONEXISTANT POLICY - NO CHANGE
+    - name: DELETE NONEXISTENT POLICY - NO CHANGE
       fortimgr_policy:
         host: "{{ inventory_hostname }}"
         session_id: "{{ session_id }}"
         lock: false
         adom: "lab"
         package: "lab"
-        policy_name: "unittest_nonexistant_policy_name"
+        policy_name: "unittest_nonexistent_policy_name"
         state: "absent"
 
     - name: CREATE DENY POLICY - CHANGE

--- a/unittests/fortimgr_policy_unittest.yml
+++ b/unittests/fortimgr_policy_unittest.yml
@@ -127,14 +127,14 @@
   tags: policy
 
   tasks:
-    - name: DELETE INEXISTANT POLICY - NO CHANGE
+    - name: DELETE NONEXISTANT POLICY - NO CHANGE
       fortimgr_policy:
         host: "{{ inventory_hostname }}"
         session_id: "{{ session_id }}"
         lock: false
         adom: "lab"
         package: "lab"
-        policy_name: "unittest_inexistant_policy_name"
+        policy_name: "unittest_nonexistant_policy_name"
         state: "absent"
 
     - name: CREATE DENY POLICY - CHANGE


### PR DESCRIPTION
Fix for fortimgr_policy crash when invoking "absent" state with inexistant policy_name