### PR TITLE
Fix issue #76: Don't fail fortimgr_install when no changes

### DIFF
--- a/library/fortimgr_install.py
+++ b/library/fortimgr_install.py
@@ -1591,6 +1591,10 @@ def main():
         install = session.install_package(proposed)
         if install["result"][0]["status"]["code"] == 0 and install["result"][0]["data"]["state"] == "done":
             results = dict(install=install, changed=True)
+        elif install["result"][0]["status"]["code"] == 0 and \
+             install["result"][0]["data"]["state"] == "warning" and \
+             install["result"][0]["data"]["line"][0]["detail"] == "no installing devices/no changes on package":
+            results = dict(install=install, changed=False)
         else:
             module.fail_json(**dict(status=install, msg="Install was NOT Sucessful; Please Check FortiManager Logs"))
 

--- a/unittests/fortimgr_install_unittest.yml
+++ b/unittests/fortimgr_install_unittest.yml
@@ -74,6 +74,24 @@
         vdom: "root"
       ignore_errors: true
 
+    - name: "INSTAL POLICY PACKAGE - NO CHANGE"
+      fortimgr_install:
+        host: "{{ ansible_host }}"
+        username: "{{ ansible_user }}"
+        password: "{{ ansible_password }}"
+        adom: "lab"
+        state: "preview"
+        adom_revision_comments: "Install Unit Test"
+        adom_revision_name: "InstallTest"
+        check_install: false
+        dst_file: "./preview.txt"
+        fortigate_name: "FortiGate-VM64-KVM"
+        fortigate_revision_comments: "Install Unit Test"
+        install_flags:
+          - "generate_rev"
+        package: "lab"
+        vdom: "root"
+      ignore_errors: true
 
 - name: "FORTIMANAGER CLEANUP INSTALL DATA"
   hosts: "fortimanager"


### PR DESCRIPTION
Don't fail fortimgr_install module when Fortimanager determines that there are no changes to be pushed to devices and simply exit successfuly with no changes.
Fixes #76