### PR TITLE
Fix issue #67: Don't escape slashes in the package name parameter

### DIFF
--- a/library/fortimgr_address.py
+++ b/library/fortimgr_address.py
@@ -340,7 +340,7 @@ class FortiManager(object):
         self.dvmdb_url = "/dvmdb/adom/{}/".format(self._escape_params_url(self.adom))
         self.obj_url = "/pm/config/adom/{}/obj/firewall/{}".format(self._escape_params_url(self.adom),
                                                                    self.api_endpoint)
-        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self._escape_params_url(self.package),
+        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self.package,
                                                                       self.api_endpoint)
         self.wsp_url = "/dvmdb/adom/{}/workspace/".format(self._escape_params_url(self.adom))
         self.headers = {"Content-Type": "application/json"}

--- a/library/fortimgr_address_group.py
+++ b/library/fortimgr_address_group.py
@@ -254,7 +254,7 @@ class FortiManager(object):
         self.dvmdb_url = "/dvmdb/adom/{}/".format(self._escape_params_url(self.adom))
         self.obj_url = "/pm/config/adom/{}/obj/firewall/{}".format(self._escape_params_url(self.adom),
                                                                    self.api_endpoint)
-        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self._escape_params_url(self.package),
+        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self.package,
                                                                       self.api_endpoint)
         self.wsp_url = "/dvmdb/adom/{}/workspace/".format(self._escape_params_url(self.adom))
         self.headers = {"Content-Type": "application/json"}

--- a/library/fortimgr_address_map.py
+++ b/library/fortimgr_address_map.py
@@ -344,7 +344,7 @@ class FortiManager(object):
         self.dvmdb_url = "/dvmdb/adom/{}/".format(self._escape_params_url(self.adom))
         self.obj_url = "/pm/config/adom/{}/obj/firewall/{}".format(self._escape_params_url(self.adom),
                                                                    self.api_endpoint)
-        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self._escape_params_url(self.package),
+        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self.package,
                                                                       self.api_endpoint)
         self.wsp_url = "/dvmdb/adom/{}/workspace/".format(self._escape_params_url(self.adom))
         self.headers = {"Content-Type": "application/json"}

--- a/library/fortimgr_facts.py
+++ b/library/fortimgr_facts.py
@@ -288,7 +288,7 @@ class FortiManager(object):
         self.dvmdb_url = "/dvmdb/adom/{}/".format(self._escape_params_url(self.adom))
         self.obj_url = "/pm/config/adom/{}/obj/firewall/{}".format(self._escape_params_url(self.adom),
                                                                    self.api_endpoint)
-        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self._escape_params_url(self.package),
+        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self.package,
                                                                       self.api_endpoint)
         self.wsp_url = "/dvmdb/adom/{}/workspace/".format(self._escape_params_url(self.adom))
         self.headers = {"Content-Type": "application/json"}

--- a/library/fortimgr_install.py
+++ b/library/fortimgr_install.py
@@ -245,7 +245,7 @@ class FortiManager(object):
         self.dvmdb_url = "/dvmdb/adom/{}/".format(self._escape_params_url(self.adom))
         self.obj_url = "/pm/config/adom/{}/obj/firewall/{}".format(self._escape_params_url(self.adom),
                                                                    self.api_endpoint)
-        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self._escape_params_url(self.package),
+        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self.package,
                                                                       self.api_endpoint)
         self.wsp_url = "/dvmdb/adom/{}/workspace/".format(self._escape_params_url(self.adom))
         self.headers = {"Content-Type": "application/json"}

--- a/library/fortimgr_ip_pool.py
+++ b/library/fortimgr_ip_pool.py
@@ -271,7 +271,7 @@ class FortiManager(object):
         self.dvmdb_url = "/dvmdb/adom/{}/".format(self._escape_params_url(self.adom))
         self.obj_url = "/pm/config/adom/{}/obj/firewall/{}".format(self._escape_params_url(self.adom),
                                                                    self.api_endpoint)
-        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self._escape_params_url(self.package),
+        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self.package,
                                                                       self.api_endpoint)
         self.wsp_url = "/dvmdb/adom/{}/workspace/".format(self._escape_params_url(self.adom))
         self.headers = {"Content-Type": "application/json"}

--- a/library/fortimgr_ip_pool_map.py
+++ b/library/fortimgr_ip_pool_map.py
@@ -310,7 +310,7 @@ class FortiManager(object):
         self.dvmdb_url = "/dvmdb/adom/{}/".format(self._escape_params_url(self.adom))
         self.obj_url = "/pm/config/adom/{}/obj/firewall/{}".format(self._escape_params_url(self.adom),
                                                                    self.api_endpoint)
-        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self._escape_params_url(self.package),
+        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self.package,
                                                                       self.api_endpoint)
         self.wsp_url = "/dvmdb/adom/{}/workspace/".format(self._escape_params_url(self.adom))
         self.headers = {"Content-Type": "application/json"}

--- a/library/fortimgr_lock.py
+++ b/library/fortimgr_lock.py
@@ -213,7 +213,7 @@ class FortiManager(object):
         self.dvmdb_url = "/dvmdb/adom/{}/".format(self._escape_params_url(self.adom))
         self.obj_url = "/pm/config/adom/{}/obj/firewall/{}".format(self._escape_params_url(self.adom),
                                                                    self.api_endpoint)
-        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self._escape_params_url(self.package),
+        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self.package,
                                                                       self.api_endpoint)
         self.wsp_url = "/dvmdb/adom/{}/workspace/".format(self._escape_params_url(self.adom))
         self.headers = {"Content-Type": "application/json"}

--- a/library/fortimgr_policy.py
+++ b/library/fortimgr_policy.py
@@ -395,7 +395,7 @@ class FortiManager(object):
         self.dvmdb_url = "/dvmdb/adom/{}/".format(self._escape_params_url(self.adom))
         self.obj_url = "/pm/config/adom/{}/obj/firewall/{}".format(self._escape_params_url(self.adom),
                                                                    self.api_endpoint)
-        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self._escape_params_url(self.package),
+        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self.package,
                                                                       self.api_endpoint)
         self.wsp_url = "/dvmdb/adom/{}/workspace/".format(self._escape_params_url(self.adom))
         self.headers = {"Content-Type": "application/json"}

--- a/library/fortimgr_revision.py
+++ b/library/fortimgr_revision.py
@@ -230,7 +230,7 @@ class FortiManager(object):
         self.dvmdb_url = "/dvmdb/adom/{}/".format(self._escape_params_url(self.adom))
         self.obj_url = "/pm/config/adom/{}/obj/firewall/{}".format(self._escape_params_url(self.adom),
                                                                    self.api_endpoint)
-        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self._escape_params_url(self.package),
+        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self.package,
                                                                       self.api_endpoint)
         self.wsp_url = "/dvmdb/adom/{}/workspace/".format(self._escape_params_url(self.adom))
         self.headers = {"Content-Type": "application/json"}

--- a/library/fortimgr_route.py
+++ b/library/fortimgr_route.py
@@ -282,7 +282,7 @@ class FortiManager(object):
         self.dvmdb_url = "/dvmdb/adom/{}/".format(self._escape_params_url(self.adom))
         self.obj_url = "/pm/config/adom/{}/obj/firewall/{}".format(self._escape_params_url(self.adom),
                                                                    self.api_endpoint)
-        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self._escape_params_url(self.package),
+        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self.package,
                                                                       self.api_endpoint)
         self.wsp_url = "/dvmdb/adom/{}/workspace/".format(self._escape_params_url(self.adom))
         self.headers = {"Content-Type": "application/json"}

--- a/library/fortimgr_service.py
+++ b/library/fortimgr_service.py
@@ -285,7 +285,7 @@ class FortiManager(object):
         self.dvmdb_url = "/dvmdb/adom/{}/".format(self._escape_params_url(self.adom))
         self.obj_url = "/pm/config/adom/{}/obj/firewall/{}".format(self._escape_params_url(self.adom),
                                                                    self.api_endpoint)
-        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self._escape_params_url(self.package),
+        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self.package,
                                                                       self.api_endpoint)
         self.wsp_url = "/dvmdb/adom/{}/workspace/".format(self._escape_params_url(self.adom))
         self.headers = {"Content-Type": "application/json"}

--- a/library/fortimgr_service_group.py
+++ b/library/fortimgr_service_group.py
@@ -239,7 +239,7 @@ class FortiManager(object):
         self.dvmdb_url = "/dvmdb/adom/{}/".format(self._escape_params_url(self.adom))
         self.obj_url = "/pm/config/adom/{}/obj/firewall/{}".format(self._escape_params_url(self.adom),
                                                                    self.api_endpoint)
-        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self._escape_params_url(self.package),
+        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self.package,
                                                                       self.api_endpoint)
         self.wsp_url = "/dvmdb/adom/{}/workspace/".format(self._escape_params_url(self.adom))
         self.headers = {"Content-Type": "application/json"}

--- a/library/fortimgr_vip.py
+++ b/library/fortimgr_vip.py
@@ -270,7 +270,7 @@ class FortiManager(object):
         self.dvmdb_url = "/dvmdb/adom/{}/".format(self._escape_params_url(self.adom))
         self.obj_url = "/pm/config/adom/{}/obj/firewall/{}".format(self._escape_params_url(self.adom),
                                                                    self.api_endpoint)
-        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self._escape_params_url(self.package),
+        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self.package,
                                                                       self.api_endpoint)
         self.wsp_url = "/dvmdb/adom/{}/workspace/".format(self._escape_params_url(self.adom))
         self.headers = {"Content-Type": "application/json"}

--- a/library/fortimgr_vip_group.py
+++ b/library/fortimgr_vip_group.py
@@ -242,7 +242,7 @@ class FortiManager(object):
         self.dvmdb_url = "/dvmdb/adom/{}/".format(self._escape_params_url(self.adom))
         self.obj_url = "/pm/config/adom/{}/obj/firewall/{}".format(self._escape_params_url(self.adom),
                                                                    self.api_endpoint)
-        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self._escape_params_url(self.package),
+        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self.package,
                                                                       self.api_endpoint)
         self.wsp_url = "/dvmdb/adom/{}/workspace/".format(self._escape_params_url(self.adom))
         self.headers = {"Content-Type": "application/json"}

--- a/library/fortimgr_vip_map.py
+++ b/library/fortimgr_vip_map.py
@@ -297,7 +297,7 @@ class FortiManager(object):
         self.dvmdb_url = "/dvmdb/adom/{}/".format(self._escape_params_url(self.adom))
         self.obj_url = "/pm/config/adom/{}/obj/firewall/{}".format(self._escape_params_url(self.adom),
                                                                    self.api_endpoint)
-        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self._escape_params_url(self.package),
+        self.pkg_url = "/pm/config/adom/{}/pkg/{}/firewall/{}".format(self._escape_params_url(self.adom), self.package,
                                                                       self.api_endpoint)
         self.wsp_url = "/dvmdb/adom/{}/workspace/".format(self._escape_params_url(self.adom))
         self.headers = {"Content-Type": "application/json"}


### PR DESCRIPTION
Don't escape slashes in the package name parameter as they are used as-is by the API to represent folder package hierarchies 
and package names can't have slashes in Fortimanager.
Fixes #67